### PR TITLE
Hot fix: Change a question on English page from Swedish to English

### DIFF
--- a/templates/EN/faq.html
+++ b/templates/EN/faq.html
@@ -26,9 +26,9 @@
     <p class="lato-black">Why should my company participate in D-Dagen?</p>
 	<p class="info-text">D-Dagen is an outstanding opportunity for Computer Science and IT companies to connect with students in different stages in their studies. Maybe you are looking for Master thesis students, part time employees, summer internships, or newly graduated MSc or PhD students? Do you want to boost your visibility as an employer, showcase your ongoing projects or share your corporate culture? Then don’t hesitate to apply to D-Dagen!</p>
 
-    <p class="lato-black">Vad mer finns att göra i samband med D-Dagen??</p>
-    <p class="info-text">Det finns möjlighet att anordna företagsevent i samband med D-Dagen. Vänligen kontakta
-        <a href="mailto:d-dagen.event@d.kth.se">d-dagen.event@d.kth.se</a> för mer information.</p>
+    <p class="lato-black">What else is there to do together with D-Dagen?</p>
+    <p class="info-text">It is possible to organise corporate events in addition to D-Dagen. Please contact
+        <a href="mailto:d-dagen.event@d.kth.se">d-dagen.event@d.kth.se</a> for more information.</p>
 
 
     <p class="lato-black">What is the D-Dagen catalogue and where can I find the catalogues from previous years?</p>

--- a/templates/EN/faq.html
+++ b/templates/EN/faq.html
@@ -26,8 +26,8 @@
     <p class="lato-black">Why should my company participate in D-Dagen?</p>
 	<p class="info-text">D-Dagen is an outstanding opportunity for Computer Science and IT companies to connect with students in different stages in their studies. Maybe you are looking for Master thesis students, part time employees, summer internships, or newly graduated MSc or PhD students? Do you want to boost your visibility as an employer, showcase your ongoing projects or share your corporate culture? Then don’t hesitate to apply to D-Dagen!</p>
 
-    <p class="lato-black">What else is there to do together with D-Dagen?</p>
-    <p class="info-text">It is possible to organise corporate events in addition to D-Dagen. Please contact
+    <p class="lato-black">What else is there to do in connection to D-Dagen?</p>
+    <p class="info-text">There is a possibility of arranging company events in connection to D-Dagen. Please contact
         <a href="mailto:d-dagen.event@d.kth.se">d-dagen.event@d.kth.se</a> for more information.</p>
 
 


### PR DESCRIPTION
One of the questions, as well as the answer, on the English FAQ page was in Swedish. This PR fixes #6 .