### PR TITLE
Hot fix: Fix spacing between application steps

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -177,7 +177,7 @@ ul#menu {
 
 #flex-boxes {
     display: flex;
-    justify-content: space-evenly;
+    justify-content: space-between;
     padding: 0;
     margin-top: 20px;
 }
@@ -185,7 +185,6 @@ ul#menu {
 .flex-box {
     float: left;
     width: 380px;
-    margin-right: 10px;
     background-color: white;
     overflow: hidden;
     color: #6a6a6a;


### PR DESCRIPTION
The spacing on the application page had the wrong setting. Space evenly instead of space between which introduced spacing on both sides of the boxes. This pull request fixes #5 .