### PR TITLE
Hot fix: Fix link text decoration on button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -217,6 +217,10 @@ ul#menu {
     border-radius: 15px;
 }
 
+.flex-box a {
+    text-decoration: none !important;
+}
+
 p.info-text {
   color: #6a6a6a;
   margin-right: 5%;


### PR DESCRIPTION
The text on a button contained a link which ment it inherited the styling of other links, underline on hover. Removed that styling from that link, fixes #7 .