### PR TITLE
Use pls for checking api keys

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ npm run dev
 This website depends on spam (not spam2!) for sending emails in production (including at http://dev.ddagen.se).
 
 It also depends on pls for checking api keys, though this can be overriden by
-setting the `PLS_OVERRIDE` to either `true` or `false`. API keys still have to
-be provided in a header when the route requires it, but the value it is given
-can be anything.
+setting the `PLS_URL` to either `true` or `false`. API keys still have to be
+provided (usually in a header) when the route requires it, but the value it is
+given can be anything.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ DATABASE_URL=postgresql://ddagen:ddagen@localhost:5432/ddagen?schema=public
 SPAM_API_KEY=2AkdhsQ9cTTSBKtNXdd6E07rqN8CFWvRqeY4GeAyXAn09urF
 SPAM_URL=https://spam.datasektionen.se/api/sendmail
 
-# In production: PLS_URL=https://pls.datasektionen.se
-# If this is set to "true" or "false", that value will be used instead of querying pls
-PLS_OVERRIDE=true
+# If this is set to "true" or "false", that value will be used instead of querying pls at the URL given.
+PLS_URL=true
+# Use `PLS_URL=https://pls.datasektionen.se` to use the real pls
 ```
 
 Install npm dependencies:

--- a/README.md
+++ b/README.md
@@ -23,16 +23,13 @@ Create a file called `.env` with contents like the following:
 ```bash
 DATABASE_URL=postgresql://ddagen:ddagen@localhost:5432/ddagen?schema=public
 
-# not used in development
+# These two are unused when NODE_ENV == "development", which it is when running `npm run dev`, but still must be set :)
 SPAM_API_KEY=2AkdhsQ9cTTSBKtNXdd6E07rqN8CFWvRqeY4GeAyXAn09urF
 SPAM_URL=https://spam.datasektionen.se/api/sendmail
 
-# can be almost anything, used to verify different endpoints
-EXPORT_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaa
-IMPORT_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaa
-DELETE_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaa
-SALES_ADMIN_USERNAME=aaaaaaaa
-SALES_ADMIN_PASSWORD=aaaaaaaaaaaaaaaaaaaaaaaa
+# In production: PLS_URL=https://pls.datasektionen.se
+# If this is set to "true" or "false", that value will be used instead of querying pls
+PLS_OVERRIDE=true
 ```
 
 Install npm dependencies:

--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ Lastly, start the thing:
 ```bash
 npm run dev
 ```
+
+## Other systems
+
+This website depends on spam (not spam2!) for sending emails in production (including at http://dev.ddagen.se).
+
+It also depends on pls for checking api keys, though this can be overriden by
+setting the `PLS_OVERRIDE` to either `true` or `false`. API keys still have to
+be provided in a header when the route requires it, but the value it is given
+can be anything.

--- a/src/components/Admin/AdminLogin.tsx
+++ b/src/components/Admin/AdminLogin.tsx
@@ -7,9 +7,9 @@ export function AdminLogin({
   login,
 }: {
   t: Locale;
-  login: (password: string) => Promise<boolean>;
+  login: (password: string) => Promise<string | undefined>;
 }) {
-  const [error, setError] = useState(false);
+  const [error, setError] = useState("");
   const [password, setPassword] = useState("");
 
   function Submit({ value }: { value: string }) {
@@ -36,7 +36,8 @@ export function AdminLogin({
         className="flex flex-col gap-12 min-w-[325px]"
         onSubmit={async (e) => {
           e.preventDefault();
-          if (!await login(password)) setError(true);
+          setError("");
+          setError(await login(password) ?? "");
         }}
       >
         <InputField
@@ -49,7 +50,7 @@ export function AdminLogin({
         <Submit value={t.login.confirm} />
       </form>
       {error && (
-        <p className="text-red-500 font-bold mt-6">{t.error.unknown}</p>
+        <p className="text-red-500 font-bold mt-6">{error}</p>
       )}
     </div>
   );

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -12,6 +12,7 @@ const server = z.object({
   SPAM_API_KEY: z.string(),
   SPAM_URL: z.string().url(),
   PLS_URL: z.string().url(),
+  PLS_OVERRIDE: z.enum(["true", "false"]).optional(),
 });
 
 /**
@@ -37,6 +38,7 @@ const processEnv = {
   SPAM_API_KEY: process.env.SPAM_API_KEY,
   SPAM_URL: process.env.SPAM_URL,
   PLS_URL: process.env.PLS_URL,
+  PLS_OVERRIDE: process.env.PLS_OVERRIDE,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
 };
 

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -11,10 +11,7 @@ const server = z.object({
   DATABASE_URL: z.string().url(),
   SPAM_API_KEY: z.string(),
   SPAM_URL: z.string().url(),
-  EXPORT_TOKEN: z.string().min(24),
-  IMPORT_TOKEN: z.string().min(24),
-  DELETE_TOKEN: z.string().min(24),
-  SALES_PASSWORD: z.string().min(24),
+  PLS_URL: z.string().url(),
 });
 
 /**
@@ -39,10 +36,7 @@ const processEnv = {
   DATABASE_URL: process.env.DATABASE_URL,
   SPAM_API_KEY: process.env.SPAM_API_KEY,
   SPAM_URL: process.env.SPAM_URL,
-  EXPORT_TOKEN: process.env.EXPORT_TOKEN,
-  IMPORT_TOKEN: process.env.IMPORT_TOKEN,
-  DELETE_TOKEN: process.env.DELETE_TOKEN,
-  SALES_PASSWORD: process.env.SALES_PASSWORD,
+  PLS_URL: process.env.PLS_URL,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
 };
 

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -11,8 +11,7 @@ const server = z.object({
   DATABASE_URL: z.string().url(),
   SPAM_API_KEY: z.string(),
   SPAM_URL: z.string().url(),
-  PLS_URL: z.string().url(),
-  PLS_OVERRIDE: z.enum(["true", "false"]).optional(),
+  PLS_URL: z.union([z.enum(["true", "false"]), z.string().url()]),
 });
 
 /**
@@ -38,7 +37,6 @@ const processEnv = {
   SPAM_API_KEY: process.env.SPAM_API_KEY,
   SPAM_URL: process.env.SPAM_URL,
   PLS_URL: process.env.PLS_URL,
-  PLS_OVERRIDE: process.env.PLS_OVERRIDE,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
 };
 

--- a/src/pages/admin/sales.tsx
+++ b/src/pages/admin/sales.tsx
@@ -11,9 +11,15 @@ export default function Sales() {
   const [exhibitors, setExhibitors] = useState<Exhibitor[]>([]);
 
   async function login(password: string) {
-    const exhibitors = await getExhibitors.mutateAsync(password);
-    setExhibitors(exhibitors);
-    return exhibitors.length > 0;
+    try {
+      const exhibitors = await getExhibitors.mutateAsync(password);
+      if (exhibitors === "invalid-password") {
+        return "invalid-password";
+      }
+      setExhibitors(exhibitors);
+    } catch (err) {
+      return "unknown-error " + err;
+    }
   }
 
   return (

--- a/src/pages/api/delete-exhibitor.ts
+++ b/src/pages/api/delete-exhibitor.ts
@@ -1,24 +1,17 @@
 import { z } from "zod";
-import { env } from "@/env.mjs";
 import { prisma } from "@/server/db";
-import { timingSafeEqual } from "crypto";
-import sendEmail from "@/utils/send-email";
 import type { NextApiRequest, NextApiResponse } from "next";
-import { validateOrganizationNumber } from "@/shared/validateOrganizationNumber";
-
-const deleteToken = Buffer.from(env.DELETE_TOKEN);
+import * as pls from "@/utils/pls";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const authHeader = req.headers["authorization"];
   if (req.method !== "DELETE") return res.status(405).end();
-  else if (
-    authHeader == undefined ||
-    authHeader.length != deleteToken.length ||
-    !timingSafeEqual(Buffer.from(authHeader), deleteToken)
-  ) {
+
+  const apiKey = req.headers["authorization"]?.split(" ")[1];
+  if (apiKey == undefined) return res.status(402).end();
+  if (!await pls.checkApiKey("write-exhibitors", apiKey)) {
     return res.status(402).end();
   }
 

--- a/src/pages/api/delete-exhibitor.ts
+++ b/src/pages/api/delete-exhibitor.ts
@@ -10,7 +10,7 @@ export default async function handler(
   if (req.method !== "DELETE") return res.status(405).end();
 
   const apiKey = req.headers["authorization"]?.split(" ")[1];
-  if (apiKey == undefined) return res.status(402).end();
+  if (apiKey == undefined) return res.status(400).end();
   if (!await pls.checkApiKey("write-exhibitors", apiKey)) {
     return res.status(402).end();
   }

--- a/src/pages/api/export-exhibitors.ts
+++ b/src/pages/api/export-exhibitors.ts
@@ -1,21 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "@/server/db";
-import { env } from "@/env.mjs";
-import { timingSafeEqual } from "crypto";
-
-const exportToken = Buffer.from(env.EXPORT_TOKEN);
+import * as pls from "@/utils/pls";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const authHeader = req.headers["authorization"];
   if (req.method !== "GET") return res.status(405).end();
-  else if (
-    authHeader == undefined ||
-    authHeader.length != exportToken.length ||
-    !timingSafeEqual(Buffer.from(authHeader), exportToken)
-  ) {
+
+  const apiKey = req.headers["authorization"]?.split(" ")[1];
+  if (apiKey == undefined) return res.status(402).end();
+  if (!await pls.checkApiKey("read-registrations", apiKey)) {
     return res.status(402).end();
   }
 
@@ -50,7 +45,7 @@ function importExhibitors() {
   const res = UrlFetchApp.fetch("https://ddagen.se/api/export-exhibitors", {
     method: "GET",
     headers: {
-      'Authorization': <whatever env.EXPORT_TOKEN is>,
+      "Authorization": "Bearer TOKEN", // Needs to have `read-registrations` on ddagen in pls
     },
   });
 
@@ -63,8 +58,8 @@ function importExhibitors() {
 
   sheet.getRange(2, 1, data.length, 6).setValues(data.map(row => [
     row.name, "'" + row.organizationNumber, row.contactPerson, "'" + row.phoneNumber, row.email, row.createdAt,
-  ])).setBackground('#eee');
-  sheet.getRange(2 + data.length, 1, 1, 6).setBackground('orange');
+  ])).setBackground("#eee");
+  sheet.getRange(2 + data.length, 1, 1, 6).setBackground("orange");
 
   sheet.autoResizeColumns(1, 7);
 }

--- a/src/pages/api/export-exhibitors.ts
+++ b/src/pages/api/export-exhibitors.ts
@@ -9,7 +9,7 @@ export default async function handler(
   if (req.method !== "GET") return res.status(405).end();
 
   const apiKey = req.headers["authorization"]?.split(" ")[1];
-  if (apiKey == undefined) return res.status(402).end();
+  if (apiKey == undefined) return res.status(400).end();
   if (!await pls.checkApiKey("read-registrations", apiKey)) {
     return res.status(402).end();
   }

--- a/src/pages/api/import-exhibitor.ts
+++ b/src/pages/api/import-exhibitor.ts
@@ -12,7 +12,7 @@ export default async function handler(
   if (req.method !== "PUT") return res.status(405).end();
 
   const apiKey = req.headers["authorization"]?.split(" ")[1];
-  if (apiKey == undefined) return res.status(402).end();
+  if (apiKey == undefined) return res.status(400).end();
   if (!await pls.checkApiKey("write-exhibitors", apiKey)) {
     return res.status(402).end();
   }

--- a/src/pages/api/import-exhibitor.ts
+++ b/src/pages/api/import-exhibitor.ts
@@ -1,24 +1,19 @@
 import { z } from "zod";
-import { env } from "@/env.mjs";
 import { prisma } from "@/server/db";
-import { timingSafeEqual } from "crypto";
 import sendEmail from "@/utils/send-email";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { validateOrganizationNumber } from "@/shared/validateOrganizationNumber";
-
-const importToken = Buffer.from(env.IMPORT_TOKEN);
+import * as pls from "@/utils/pls";
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const authHeader = req.headers["authorization"];
   if (req.method !== "PUT") return res.status(405).end();
-  else if (
-    authHeader == undefined ||
-    authHeader.length != importToken.length ||
-    !timingSafeEqual(Buffer.from(authHeader), importToken)
-  ) {
+
+  const apiKey = req.headers["authorization"]?.split(" ")[1];
+  if (apiKey == undefined) return res.status(402).end();
+  if (!await pls.checkApiKey("write-exhibitors", apiKey)) {
     return res.status(402).end();
   }
 
@@ -118,7 +113,7 @@ export default async function handler(
       <p>The D-Dagen Team</p>
       `
     );
-  } catch (e) {}
+  } catch (e) { }
 
   res.status(200).end();
 }

--- a/src/utils/pls.ts
+++ b/src/utils/pls.ts
@@ -3,9 +3,12 @@ import { env } from "@/env.mjs";
 type Permission = "write-exhibitors" | "read-registrations";
 
 export async function checkApiKey(permission: Permission, apiKey: string): Promise<boolean> {
+  if (typeof env.PLS_OVERRIDE == "string") {
+    return env.PLS_OVERRIDE == "true";
+  }
+
   let allowed = false;
   try {
-    console.log(`${env.PLS_URL}/api/token/${encodeURIComponent(apiKey)}/ddagen/${permission}`);
     const res = await fetch(`${env.PLS_URL}/api/token/${encodeURIComponent(apiKey)}/ddagen/${permission}`);
     if (res.status !== 200) {
       console.error("pls request failed with status code:", res.status);

--- a/src/utils/pls.ts
+++ b/src/utils/pls.ts
@@ -1,0 +1,19 @@
+import { env } from "@/env.mjs";
+
+type Permission = "write-exhibitors" | "read-registrations";
+
+export async function checkApiKey(permission: Permission, apiKey: string): Promise<boolean> {
+  let allowed = false;
+  try {
+    console.log(`${env.PLS_URL}/api/token/${encodeURIComponent(apiKey)}/ddagen/${permission}`);
+    const res = await fetch(`${env.PLS_URL}/api/token/${encodeURIComponent(apiKey)}/ddagen/${permission}`);
+    if (res.status !== 200) {
+      console.error("pls request failed with status code:", res.status);
+      return false;
+    }
+    allowed = (await res.json()) === true;
+  } catch (err) {
+    console.error("pls request failed:", err);
+  }
+  return allowed;
+}

--- a/src/utils/pls.ts
+++ b/src/utils/pls.ts
@@ -1,10 +1,13 @@
 import { env } from "@/env.mjs";
 
-type Permission = "write-exhibitors" | "read-registrations";
+type Permission = "read-exhibitors" | "write-exhibitors" | "read-registrations";
 
 export async function checkApiKey(permission: Permission, apiKey: string): Promise<boolean> {
-  if (typeof env.PLS_OVERRIDE == "string") {
-    return env.PLS_OVERRIDE == "true";
+  if (env.PLS_URL === "true") {
+    return true;
+  }
+  if (env.PLS_URL === "false") {
+    return false;
   }
 
   let allowed = false;


### PR DESCRIPTION
This PR makes use of [pls](https://pls.datasektionen.se) to verify api keys, as it's easier (imo) to manage than having a bunch of environment variables.

When running locally, it can be cumbersome to have to run pls locally and unnecessary to need a real api key, so I added the optional environment variable `PLS_OVERRIDE` which can be used to allow or deny every api key without checking with pls.

Apparently i also threw in a `.editorconfig`.