### PR TITLE
Minor fixes

### DIFF
--- a/prisma/migrations/20230822103841_login_codes_valid_until_instead_of_created_at/migration.sql
+++ b/prisma/migrations/20230822103841_login_codes_valid_until_instead_of_created_at/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "login_codes" ADD COLUMN "validUntil" TIMESTAMP(3);
+
+UPDATE "login_codes"
+SET "validUntil" = "createdAt" + interval '10' minute;
+
+ALTER TABLE "login_codes" DROP COLUMN "createdAt";
+
+ALTER TABLE "login_codes" ALTER COLUMN "validUntil" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,8 +64,8 @@ model User {
 }
 
 model LoginCode {
-  id        String   @id @db.Char(32)
-  createdAt DateTime @default(now())
+  id         String   @id @db.Char(32)
+  validUntil DateTime
 
   userId String @unique
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/src/components/Admin/AdminLogin.tsx
+++ b/src/components/Admin/AdminLogin.tsx
@@ -1,28 +1,16 @@
 import Locale from "@/locales";
-import { api } from "@/utils/api";
-import { useState, useEffect, Dispatch } from "react";
+import { useState } from "react";
 import { InputField } from "@/components/InputField";
 
 export function AdminLogin({
   t,
-  password,
-  setPassword,
-  setIsLoggedIn,
+  login,
 }: {
   t: Locale;
-  password: string;
-  setPassword: Dispatch<string>;
-  setIsLoggedIn: Dispatch<boolean>;
+  login: (password: string) => Promise<boolean>;
 }) {
-  const confirmSalesAdmin = api.account.confirmSalesAdmin.useMutation();
-
   const [error, setError] = useState(false);
-  const [username, setUsername] = useState("");
-
-  useEffect(() => {
-    if (confirmSalesAdmin.data == true) setIsLoggedIn(true);
-    else if (confirmSalesAdmin.data == false) setError(true);
-  }, [confirmSalesAdmin]);
+  const [password, setPassword] = useState("");
 
   function Submit({ value }: { value: string }) {
     return (
@@ -30,10 +18,10 @@ export function AdminLogin({
         type="submit"
         value={value}
         className="
-              bg-cerise transition-transform hover:scale-110 focus:scale-110
-              focus:outline-none text-white uppercase w-fit mx-auto py-2 px-10
-              rounded-full cursor-pointer disabled:cursor-wait disabled:grayscale
-            "
+          bg-cerise transition-transform hover:scale-110 focus:scale-110
+          focus:outline-none text-white uppercase w-fit mx-auto py-2 px-10
+          rounded-full cursor-pointer disabled:cursor-wait disabled:grayscale
+        "
       />
     );
   }
@@ -46,18 +34,11 @@ export function AdminLogin({
 
       <form
         className="flex flex-col gap-12 min-w-[325px]"
-        onSubmit={(e) => {
+        onSubmit={async (e) => {
           e.preventDefault();
-          confirmSalesAdmin.mutate({ username: username, password: password });
+          if (!await login(password)) setError(true);
         }}
       >
-        <InputField
-          name="username"
-          value={username}
-          type="text"
-          setValue={setUsername}
-          fields={{ username: t.admin.login.username }}
-        />
         <InputField
           name="password"
           value={password}

--- a/src/components/Admin/ExhibitorPanel.tsx
+++ b/src/components/Admin/ExhibitorPanel.tsx
@@ -1,42 +1,14 @@
 import Locale from "@/locales";
-import { api } from "@/utils/api";
-import { useState, useEffect } from "react";
 import { Exhibitor } from "@/shared/Classes";
 import { addImageDetails } from "@/shared/addImageDetails";
 
 export function ExhibitorPanel({
   t,
-  password,
+  exhibitors,
 }: {
   t: Locale;
-  password: string;
+  exhibitors: Exhibitor[];
 }) {
-  const defaultExhibitor = new Exhibitor(
-    "",
-    "",
-    "",
-    "",
-    undefined,
-    undefined,
-    "",
-    "",
-    0,
-    0,
-    0,
-    0,
-    0,
-    ""
-  );
-  const [exhibitors, setExhibitors] = useState([defaultExhibitor]);
-
-  // Queries
-  const getExhibitors = api.exhibitor.getExhibitors.useQuery(password);
-
-  useEffect(() => {
-    if (!getExhibitors.isSuccess) return;
-    setExhibitors([defaultExhibitor].concat(getExhibitors.data));
-  }, [getExhibitors.isSuccess]);
-
   return (
     <div className="w-full h-full my-48 text-white">
       {/*Header*/}
@@ -61,7 +33,7 @@ export function ExhibitorPanel({
             className="[&>tr>td]:border-r-2 [&>tr>td]:border-t-2 [&>tr>td]:border-solid 
                       [&>tr>td]:border-white [&>tr>td]:p-4"
           >
-            {exhibitors.slice(1).map((exhibitor, i) => (
+            {exhibitors.map((exhibitor, i) => (
               <tr key={i}>
                 <td className="text-center break-words">{exhibitor.name}</td>
                 <td>

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -42,7 +42,7 @@ const processEnv = {
   EXPORT_TOKEN: process.env.EXPORT_TOKEN,
   IMPORT_TOKEN: process.env.IMPORT_TOKEN,
   DELETE_TOKEN: process.env.DELETE_TOKEN,
-  SALES_PASSWORD: process.env.SALES_ADMIN_PASSWORD,
+  SALES_PASSWORD: process.env.SALES_PASSWORD,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
 };
 

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -14,7 +14,6 @@ const server = z.object({
   EXPORT_TOKEN: z.string().min(24),
   IMPORT_TOKEN: z.string().min(24),
   DELETE_TOKEN: z.string().min(24),
-  SALES_USERNAME: z.string().min(8),
   SALES_PASSWORD: z.string().min(24),
 });
 
@@ -43,7 +42,6 @@ const processEnv = {
   EXPORT_TOKEN: process.env.EXPORT_TOKEN,
   IMPORT_TOKEN: process.env.IMPORT_TOKEN,
   DELETE_TOKEN: process.env.DELETE_TOKEN,
-  SALES_USERNAME: process.env.SALES_ADMIN_USERNAME,
   SALES_PASSWORD: process.env.SALES_ADMIN_PASSWORD,
   // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
 };

--- a/src/pages/admin/sales.tsx
+++ b/src/pages/admin/sales.tsx
@@ -2,23 +2,29 @@ import { useState } from "react";
 import { useLocale } from "@/locales";
 import { AdminLogin } from "../../components/Admin/AdminLogin";
 import { ExhibitorPanel } from "../../components/Admin/ExhibitorPanel";
+import { api } from "@/utils/api";
+import type { Exhibitor } from "@/shared/Classes";
 
 export default function Sales() {
   const t = useLocale();
-  const [password, setPassword] = useState("");
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const getExhibitors = api.exhibitor.getExhibitors.useMutation();
+  const [exhibitors, setExhibitors] = useState<Exhibitor[]>([]);
+
+  async function login(password: string) {
+    const exhibitors = await getExhibitors.mutateAsync(password);
+    setExhibitors(exhibitors);
+    return exhibitors.length > 0;
+  }
 
   return (
     <div>
-      {!isLoggedIn ? (
+      {exhibitors.length === 0 ? (
         <AdminLogin
           t={t}
-          password={password}
-          setPassword={setPassword}
-          setIsLoggedIn={setIsLoggedIn}
+          login={login}
         />
       ) : (
-        <ExhibitorPanel t={t} password={password} />
+        <ExhibitorPanel t={t} exhibitors={exhibitors} />
       )}
     </div>
   );

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { env } from "@/env.mjs";
 import { getLocale } from "@/locales";
 import sendEmail from "@/utils/send-email";
 import { Prisma, type PrismaClient } from "@prisma/client";
@@ -101,23 +100,6 @@ export const accountRouter = createTRPCRouter({
       `session=; Path=/; HttpOnly; SameSite=Lax; Secure`
     );
   }),
-  confirmSalesAdmin: publicProcedure
-    .input(
-      z.object({
-        username: z.string(),
-        password: z.string(),
-      })
-    )
-    .mutation(({ input }) => {
-      const username = Buffer.from(env.SALES_USERNAME);
-      const password = Buffer.from(env.SALES_PASSWORD);
-      return (
-        input.username.length == username.length &&
-        timingSafeEqual(Buffer.from(input.username), username) &&
-        input.password.length == password.length &&
-        timingSafeEqual(Buffer.from(input.password), password)
-      );
-    }),
 });
 
 // TODO: Unused login codes that expire are never cleaned up. This shouldn't be a huge problem,

--- a/src/server/api/routers/account.ts
+++ b/src/server/api/routers/account.ts
@@ -16,12 +16,13 @@ async function createCode(
   const loginCode = randomBytes(24).toString("base64url");
   // TODO: make url configurable
   const magicLink = "https://ddagen.se/logga-in?code=" + loginCode;
+  const validUntil = new Date(Date.now() + 1000 * 60 * 10); // 10 minutes
   await prisma.$transaction([
     prisma.loginCode.deleteMany({
       where: { userId: userId },
     }),
     prisma.loginCode.create({
-      data: { id: loginCode, userId: userId },
+      data: { id: loginCode, userId, validUntil },
     }),
   ]);
 
@@ -67,7 +68,7 @@ export const accountRouter = createTRPCRouter({
       } else {
         return { error: "invalidConfirmationCode" as const };
       }
-      if (loginCode.createdAt < new Date(Date.now() - 1000 * 60 * 10)) {
+      if (loginCode.validUntil < new Date()) {
         return { error: "invalidConfirmationCode" as const };
       }
 

--- a/src/server/api/routers/exhibitor.ts
+++ b/src/server/api/routers/exhibitor.ts
@@ -458,7 +458,7 @@ export const exhibitorRouter = createTRPCRouter({
     }),
   getExhibitors: publicProcedure
     .input(z.string())
-    .query(async ({ input, ctx }) => {
+    .mutation(async ({ input, ctx }) => {
       const password = Buffer.from(env.SALES_PASSWORD);
       if (
         input.length == password.length &&


### PR DESCRIPTION
- Rename `SALES_ADMIN_PASSWORD` to `SALES_PASSWORD` to match what's in the code.
- Remove the `confirmSalesAdmin` procedure.
- Improve db query in `finishLogin` to avoid uninformative error logs
- Make login codes have a `validUntil` instead of `createdAt`. If we need to create one manually, this makes more sense.