### PR TITLE
Fix some bugs when admins log in as exhibitors

### DIFF
--- a/src/components/Admin/ExhibitorPanel.tsx
+++ b/src/components/Admin/ExhibitorPanel.tsx
@@ -16,12 +16,20 @@ export function ExhibitorPanel({
 }) {
   const router = useRouter();
   const login = api.admin.login.useMutation();
+  const trpc = api.useContext();
 
   useEffect(() => {
     if (login.isSuccess) {
       router.push("/utställare");
     }
   }, [login.isSuccess]);
+
+  function getLoginFunction(exhibitorId: string) {
+    return async () => {
+      await trpc.invalidate();
+      login.mutate({ exhibitorId: exhibitorId, password });
+    };
+  }
 
   return (
     <div className="w-full h-full text-white">
@@ -54,7 +62,7 @@ export function ExhibitorPanel({
                     <p>{exhibitor.name}</p>
                     <button
                       className="mt-2 bg-cerise bg-blue-500 py-1 px-2 rounded-md"
-                      onClick={() => login.mutate({ exhibitorId: exhibitor.id, password })}
+                      onClick={getLoginFunction(exhibitor.id)}
                     >{t.admin.sales.login}</button>
                   </td>
                   <td>

--- a/src/components/Settings/RowOne.tsx
+++ b/src/components/Settings/RowOne.tsx
@@ -133,12 +133,12 @@ export default function RowOne({ t }: { t: Locale }) {
     if (!getLogos.isSuccess) return;
     setWhiteLogo(addImageDetails(getLogos.data.white));
     setColorLogo(addImageDetails(getLogos.data.color));
-  }, [getLogos.isSuccess]);
+  }, [getLogos.data]);
 
   useEffect(() => {
     if (!getDescription.isSuccess) return;
     setDescription(getDescription.data.description);
-  }, [getDescription.isSuccess]);
+  }, [getDescription.data]);
 
   useEffect(() => {
     if (!getJobOffers.isSuccess || !getJobOffers.data) return;
@@ -157,7 +157,7 @@ export default function RowOne({ t }: { t: Locale }) {
     initCheckMarks[16] = jobOffers.fullTimeJob;
     initCheckMarks[17] = jobOffers.traineeProgram;
     setCheckMarks(initCheckMarks);
-  }, [getJobOffers.isSuccess]);
+  }, [getJobOffers.data]);
 
   useEffect(() => {
     if (typeof saveChanges === "boolean") {

--- a/src/pages/utst%C3%A4llare.tsx
+++ b/src/pages/utst%C3%A4llare.tsx
@@ -22,7 +22,6 @@ export default function Exhibitor() {
   const [exhibitorPackage, setExhibitorPackage] = useState(new Package(t, ""));
 
   // Mutations
-  const logout = api.account.logout.useMutation();
   const setExtrasMutation = api.exhibitor.setExtras.useMutation();
 
   // Queries
@@ -41,13 +40,6 @@ export default function Exhibitor() {
   }, [isLoggedIn]);
 
   useEffect(() => {
-    if (logout.isSuccess) {
-      router.push("/");
-      trpc.account.invalidate();
-    }
-  }, [logout.isSuccess]);
-
-  useEffect(() => {
     if (!getExtras.isSuccess) return;
     setExtras(
       new Extras(
@@ -58,12 +50,12 @@ export default function Exhibitor() {
         getExtras.data.totalBanquetTicketsWanted
       )
     );
-  }, [getExtras.isSuccess]);
+  }, [getExtras.data]);
 
   useEffect(() => {
     if (!getPreferenceCounts.isSuccess) return;
     setPreferenceCount(getPreferenceCounts.data);
-  }, [getExtras.isSuccess]);
+  }, [getExtras.data]);
 
   useEffect(() => {
     if (!getExhibitor.isSuccess) return;
@@ -77,7 +69,7 @@ export default function Exhibitor() {
       exhibitor.customBanquetTicketsWanted
     );
     setExhibitorPackage(exhibitorPackage);
-  }, [getExhibitor.isSuccess]);
+  }, [getExhibitor.data]);
 
   useEffect(() => {
     if (!getExtras.isSuccess) return;


### PR DESCRIPTION
- When switching to another exhibitor without reloading the page, data from the previous exhibitor was still shown since the queries never switched state from `isSuccess == true`, but still had new values in `data`.
- There was also a bug that made all login buttons log in to the exhibitor last in the list.