### PR TITLE
fix(app): Bug in admin page

### DIFF
--- a/src/components/Settings/AddPreferences.tsx
+++ b/src/components/Settings/AddPreferences.tsx
@@ -23,7 +23,7 @@ export function AddPreferences({
   t: Locale;
   pos: number;
   type: "Representative" | "Banquet";
-  extras: Extras;
+  extras: Extras | undefined;
   preferences: Preferences[];
   setPreferences: Dispatch<Preferences[]>;
   preferenceCount: { banqcount: number; reprcount: number };
@@ -41,6 +41,7 @@ export function AddPreferences({
     false,
     false,
   ]);
+  const [extraPreferences, setExtraPreferences] = useState(0);
   const [preference, setPreference] = useState(preferences[pos]);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
@@ -71,9 +72,6 @@ export function AddPreferences({
     const maxPreferences = isRepresentative
       ? exhibitorPackage.representatives
       : exhibitorPackage.banquetTickets;
-    const extraPreferences = isRepresentative
-      ? extras.extraRepresentativeSpots
-      : extras.totalBanquetTicketsWanted;
     if (
       preference.id ||
       preferences.length <= maxPreferences + extraPreferences
@@ -174,6 +172,15 @@ export function AddPreferences({
       }, 3000);
     }
   }, [errorMessage]);
+
+  useEffect(() => {
+    if (extras == undefined) return;
+    setExtraPreferences(
+      isRepresentative
+        ? extras.extraRepresentativeSpots
+        : extras.totalBanquetTicketsWanted
+    );
+  }, [extras]);
 
   return (
     <div className="flex flex-col items-center w-[80%] bg-white/40 border-2 border-white/70 rounded-xl pb-8 mt-8 mb-16 overflow-hidden">

--- a/src/components/Settings/ExtraOrders.tsx
+++ b/src/components/Settings/ExtraOrders.tsx
@@ -10,8 +10,8 @@ export default function ExtraOrders({
   exhibitorPackage,
 }: {
   t: Locale;
-  extras: Extras;
-  setExtras: Dispatch<Extras>;
+  extras: Extras | undefined;
+  setExtras: Dispatch<Extras | undefined>;
   preferenceCount: { banqcount: number; reprcount: number };
   exhibitorPackage: Package;
 }) {
@@ -31,6 +31,7 @@ export default function ExtraOrders({
   const [banquetTickets, setBanquetTickets] = useState(0);
 
   useEffect(() => {
+    if (extras == undefined) return;
     setTables(extras.extraTables);
     setChairs(extras.extraChairs);
     setDrinkCoupons(extras.extraDrinkCoupons);

--- a/src/components/Settings/PreferenceDetails.tsx
+++ b/src/components/Settings/PreferenceDetails.tsx
@@ -15,7 +15,7 @@ export function PreferenceDetails({
 }: {
   t: Locale;
   type: "Banquet" | "Representative";
-  extras: Extras;
+  extras: Extras | undefined;
   preferenceCount: { banqcount: number; reprcount: number };
   setPreferenceCount: Dispatch<{ banqcount: number; reprcount: number }>;
   exhibitorPackage: Package;

--- a/src/components/Settings/RowThree.tsx
+++ b/src/components/Settings/RowThree.tsx
@@ -11,7 +11,7 @@ export default function RowThree({
   exhibitorPackage,
 }: {
   t: Locale;
-  extras: Extras;
+  extras: Extras | undefined;
   preferenceCount: { banqcount: number; reprcount: number };
   setPreferenceCount: Dispatch<{ banqcount: number; reprcount: number }>;
   exhibitorPackage: Package;

--- a/src/components/Settings/RowTwo.tsx
+++ b/src/components/Settings/RowTwo.tsx
@@ -11,8 +11,8 @@ export default function RowTwo({
   exhibitorPackage,
 }: {
   t: Locale;
-  extras: Extras;
-  setExtras: Dispatch<Extras>;
+  extras: Extras | undefined;
+  setExtras: Dispatch<Extras | undefined>;
   preferenceCount: { banqcount: number; reprcount: number };
   exhibitorPackage: Package;
 }) {

--- a/src/pages/admin/sales.tsx
+++ b/src/pages/admin/sales.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
 import { useLocale } from "@/locales";
+import { useRouter } from "next/router";
+import { useState, useEffect } from "react";
 import ButtonGroup from "@/components/ButtonGroup";
 import { AdminLogin } from "@/components/Admin/AdminLogin";
 import { ExhibitorPanel } from "@/components/Admin/ExhibitorPanel";
@@ -10,13 +11,17 @@ import { api } from "@/utils/api";
 
 export default function Sales() {
   const t = useLocale();
-  const getExhibitors = api.admin.getExhibitors.useMutation();
-  const [exhibitors, setExhibitors] = useState<Exhibitor[]>([]);
-  const getFoodPreferences = api.admin.getAllFoodPreferences.useMutation();
+  const router = useRouter();
+  const trpc = api.useContext();
 
+  const [exhibitors, setExhibitors] = useState<Exhibitor[]>([]);
   const [preferences, setPreferences] = useState<Preferences[]>([]);
   const [buttonSelected, setButtonSelected] = useState<1 | 2 | 3>(1);
   const [password, setPassword] = useState<string>("");
+
+  const logout = api.admin.logout.useMutation();
+  const getExhibitors = api.admin.getExhibitors.useMutation();
+  const getFoodPreferences = api.admin.getAllFoodPreferences.useMutation();
 
   async function login(password: string) {
     try {
@@ -35,6 +40,17 @@ export default function Sales() {
       return "unknown-error " + err;
     }
   }
+
+  useEffect(() => {
+    logout.mutate();
+  }, []);
+
+  useEffect(() => {
+    if (logout.isSuccess && logout.data.status) {
+      trpc.account.invalidate();
+      router.reload();
+    }
+  }, [logout.isSuccess]);
 
   return (
     <div>

--- a/src/pages/logga-in.tsx
+++ b/src/pages/logga-in.tsx
@@ -4,13 +4,7 @@ import { api } from "@/utils/api";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-function Submit({
-  value,
-  loading,
-}: {
-  value: string;
-  loading: boolean;
-}) {
+function Submit({ value, loading }: { value: string; loading: boolean }) {
   return (
     <input
       type="submit"
@@ -31,13 +25,23 @@ export default function Login() {
   const locale = t.locale;
   const trpc = api.useContext();
 
+  const [code, setCode] = useState("");
+  const [email, setEmail] = useState("");
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>();
   const [state, setState] = useState<"email" | "code">("email");
 
-  const [email, setEmail] = useState("");
   const startLogin = api.account.startLogin.useMutation();
-
-  const [code, setCode] = useState("");
   const finishLogin = api.account.finishLogin.useMutation();
+  const getIsLoggedIn = api.account.isLoggedIn.useQuery(undefined, {
+    onSuccess: (data) => {
+      setIsLoggedIn(data);
+    },
+  });
+
+  useEffect(() => {
+    if (!getIsLoggedIn.isSuccess) return;
+    if (isLoggedIn == true) router.push("/utst%C3%A4llare");
+  }, [isLoggedIn]);
 
   useEffect(() => {
     if (startLogin.isSuccess) {
@@ -62,45 +66,66 @@ export default function Login() {
 
   return (
     <div className="mx-auto flex flex-col items-center text-center mb-40">
-      <h1 className="text-cerise pt-[200px] mb-16 text-5xl font-medium uppercase">{t.login.title}</h1>
-      {state === "email" ? <>
-        <form className="flex flex-col gap-6" onSubmit={(e) => {
-          e.preventDefault();
-          startLogin.mutate({ email, locale });
-        }}>
-          <InputField
-            name="email"
-            value={email}
-            type="email"
-            setValue={setEmail}
-            fields={{ email: t.login.email }}
-          />
-          <p className="text-white max-w-xs">{t.login.emailText}</p>
-          <Submit value={t.login.confirm} loading={startLogin.isLoading} />
-        </form>
-        {startLogin.error && (
-          <p className="text-red-500 font-bold mt-6">{t.error.unknown}</p>
-        )}
-      </> : <>
-        <form className="flex flex-col gap-6 items-center" onSubmit={(e) => { e.preventDefault(); finishLogin.mutate(code); }}>
-          <InputField
-            name="code"
-            value={code}
-            type="text"
-            setValue={setCode}
-            fields={{ code: t.login.confirmationCode }}
-            class="w-96"
-          />
-          <p className="text-white max-w-xs">{t.login.confirmationCodeText1}<span className="font-bold">{email}</span>{t.login.confirmationCodeText2}</p>
-          <Submit value={t.login.confirm} loading={finishLogin.isLoading} />
-        </form>
-        {finishLogin.data?.error && (
-          <p className="text-red-500 font-bold mt-6">{t.error[finishLogin.data.error]}</p>
-        )}
-        {finishLogin.error && (
-          <p className="text-red-500 font-bold mt-6">{t.error.unknown}</p>
-        )}
-      </>}
+      <h1 className="text-cerise pt-[200px] mb-16 text-5xl font-medium uppercase">
+        {t.login.title}
+      </h1>
+      {state === "email" ? (
+        <>
+          <form
+            className="flex flex-col gap-6"
+            onSubmit={(e) => {
+              e.preventDefault();
+              startLogin.mutate({ email, locale });
+            }}
+          >
+            <InputField
+              name="email"
+              value={email}
+              type="email"
+              setValue={setEmail}
+              fields={{ email: t.login.email }}
+            />
+            <p className="text-white max-w-xs">{t.login.emailText}</p>
+            <Submit value={t.login.confirm} loading={startLogin.isLoading} />
+          </form>
+          {startLogin.error && (
+            <p className="text-red-500 font-bold mt-6">{t.error.unknown}</p>
+          )}
+        </>
+      ) : (
+        <>
+          <form
+            className="flex flex-col gap-6 items-center"
+            onSubmit={(e) => {
+              e.preventDefault();
+              finishLogin.mutate(code);
+            }}
+          >
+            <InputField
+              name="code"
+              value={code}
+              type="text"
+              setValue={setCode}
+              fields={{ code: t.login.confirmationCode }}
+              class="w-96"
+            />
+            <p className="text-white max-w-xs">
+              {t.login.confirmationCodeText1}
+              <span className="font-bold">{email}</span>
+              {t.login.confirmationCodeText2}
+            </p>
+            <Submit value={t.login.confirm} loading={finishLogin.isLoading} />
+          </form>
+          {finishLogin.data?.error && (
+            <p className="text-red-500 font-bold mt-6">
+              {t.error[finishLogin.data.error]}
+            </p>
+          )}
+          {finishLogin.error && (
+            <p className="text-red-500 font-bold mt-6">{t.error.unknown}</p>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/utst%C3%A4llare.tsx
+++ b/src/pages/utst%C3%A4llare.tsx
@@ -11,10 +11,9 @@ import RowThree from "@/components/Settings/RowThree";
 export default function Exhibitor() {
   const t = useLocale();
   const router = useRouter();
-  const trpc = api.useContext();
 
   const [extras, setExtras] = useState<Extras>();
-  const [isLoggedIn, setIsLoggedIn] = useState<boolean | undefined>(undefined);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>();
   const [preferenceCount, setPreferenceCount] = useState({
     banqcount: 0,
     reprcount: 0,

--- a/src/pages/utst%C3%A4llare.tsx
+++ b/src/pages/utst%C3%A4llare.tsx
@@ -13,7 +13,7 @@ export default function Exhibitor() {
   const router = useRouter();
   const trpc = api.useContext();
 
-  const [extras, setExtras] = useState(new Extras(0, 0, 0, 0, 0));
+  const [extras, setExtras] = useState<Extras>();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | undefined>(undefined);
   const [preferenceCount, setPreferenceCount] = useState({
     banqcount: 0,
@@ -72,7 +72,7 @@ export default function Exhibitor() {
   }, [getExhibitor.data]);
 
   useEffect(() => {
-    if (!getExtras.isSuccess) return;
+    if (extras == undefined) return;
     setExtrasMutation.mutate({
       extraTables: extras.extraTables,
       extraChairs: extras.extraChairs,

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -75,4 +75,14 @@ export const adminRouter = createTRPCRouter({
         `session=${session.id}; Path=/; HttpOnly; SameSite=Lax; Secure`
       );
     }),
+  logout: publicProcedure.mutation(async ({ ctx }) => {
+    if (ctx.session) {
+      await ctx.prisma.session.delete({ where: { id: ctx.session.id } });
+      ctx.res.setHeader(
+        "Set-Cookie",
+        `session=; Path=/; HttpOnly; SameSite=Lax; Secure`
+      );
+    }
+    return { status: ctx.session ? true : false };
+  }),
 });


### PR DESCRIPTION
* Due to how admins simply returned to the login page after making changes, the getExtras mutation was still true which meant that the setExtras mutation would run twice, resulting in a race condition (see image below). If the default extras object was last the exhibitor details would reset. 
* An unnoticed bug, derived from the same issue of variables not changing, is preferences not updating properly (and other things most likely). We now log out and reload the admin page. 
* Made sure that user can't access login page if they are already logged in.

![image](https://github.com/datasektionen/ddagen/assets/66337956/3167dc57-8b3c-45de-8bfc-d41a7315e287)

